### PR TITLE
Ensure profile card updates with games

### DIFF
--- a/Alua/Services/ViewModels/SettingsVM.cs
+++ b/Alua/Services/ViewModels/SettingsVM.cs
@@ -50,6 +50,16 @@ public partial class SettingsVM  : ObservableObject
         _games = new();
     }
 
+    /// <summary>
+    /// Adds or updates a game in the collection and notifies listeners.
+    /// </summary>
+    /// <param name="game">Game to add or update.</param>
+    public void AddOrUpdateGame(Game game)
+    {
+        _games[game.Identifier] = game;
+        OnPropertyChanged(nameof(Games));
+    }
+
 
     /// <summary>
     /// Saves settings to disk

--- a/Alua/UI/Controls/ProfileCard.xaml.cs
+++ b/Alua/UI/Controls/ProfileCard.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using System.ComponentModel;
 using SettingsVM = Alua.Services.ViewModels.SettingsVM;
 
 namespace Alua.UI.Controls;
@@ -36,5 +37,14 @@ public sealed partial class ProfileCard : UserControl
     public ProfileCard()
     {
         InitializeComponent();
+        settingsVM.PropertyChanged += SettingsVMOnPropertyChanged;
+    }
+
+    private void SettingsVMOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsVM.Games))
+        {
+            Bindings.Update();
+        }
     }
 }

--- a/Alua/UI/GameList.xaml.cs
+++ b/Alua/UI/GameList.xaml.cs
@@ -127,7 +127,7 @@ public partial class GameList : Page
             
             foreach (var game in games)
             {
-                _settingsVM.Games[game.Identifier]= game;
+                _settingsVM.AddOrUpdateGame(game);
             }
             
             Log.Information("Found {Count} games from provider", games.Length);
@@ -187,9 +187,9 @@ public partial class GameList : Page
         }
         
         // Update or add new games.
-        foreach (var newGame in games) 
+        foreach (var newGame in games)
         {
-            _settingsVM.Games[newGame.Identifier] = newGame;
+            _settingsVM.AddOrUpdateGame(newGame);
         }
 
         // Clear and repopulate FilteredGames with ALL games from memory

--- a/Alua/UI/GamePage.xaml.cs
+++ b/Alua/UI/GamePage.xaml.cs
@@ -63,7 +63,7 @@ public sealed partial class GamePage : Page
 
         //Update settings collection and this page's binding source.
         Game game = await provider.RefreshTitle(AppVM.SelectedGame.Identifier);
-        Ioc.Default.GetRequiredService<SettingsVM>().Games[AppVM.SelectedGame.Identifier] = game;
+        Ioc.Default.GetRequiredService<SettingsVM>().AddOrUpdateGame(game);
         AppVM.SelectedGame = game;
 
         await Ioc.Default.GetRequiredService<SettingsVM>().Save();


### PR DESCRIPTION
## Summary
- add `AddOrUpdateGame` helper on `SettingsVM`
- listen for changes to `SettingsVM.Games` in `ProfileCard`
- use helper when updating game library

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ec62b2928833098774fc291c497e1