### PR TITLE
Add last updated field and recent sort option

### DIFF
--- a/Alua/Models/Game.cs
+++ b/Alua/Models/Game.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 
@@ -25,6 +26,12 @@ public class Game
     /// </summary>
     [JsonInclude, JsonPropertyName("Icon")]
     public string Icon { get; set; }
+
+    /// <summary>
+    /// Last time the game information was updated
+    /// </summary>
+    [JsonInclude, JsonPropertyName("LastUpdated")]
+    public DateTime LastUpdated { get; set; }
     
     /// <summary>
     /// Total playtime in minutes
@@ -55,6 +62,7 @@ public class Game
         Icon = string.Empty;
         Achievements = new ObservableCollection<Achievement>();
         Identifier = string.Empty;
+        LastUpdated = DateTime.UtcNow;
     }
 
     #region UI Helpers

--- a/Alua/Services/Providers/RetroAchivementsService.cs
+++ b/Alua/Services/Providers/RetroAchivementsService.cs
@@ -1,3 +1,4 @@
+using System;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Sachya;
 using Serilog;
@@ -57,7 +58,8 @@ public class RetroAchievementsService : IAchievementProvider<RetroAchievementsSe
                 Platform = Platforms.RetroAchievements, // Ensure your Platforms enum contains this value.
                 PlaytimeMinutes = -1, // RetroAchievements does not provide playtime data.
                 Achievements = (await GetAchievements(completed.GameID)).ToObservableCollection(),
-                Identifier = "ra-"+completed.GameID
+                Identifier = "ra-"+completed.GameID,
+                LastUpdated = DateTime.UtcNow
             };
 
             // Add game to collection, update progress message
@@ -87,7 +89,8 @@ public class RetroAchievementsService : IAchievementProvider<RetroAchievementsSe
                 Platform = Platforms.RetroAchievements, // Ensure your Platforms enum contains this value.
                 PlaytimeMinutes = -1, // RetroAchievements does not provide playtime data.
                 Achievements = (await GetAchievements(game.GameID)).ToObservableCollection(),
-                Identifier = "ra-"+game.GameID
+                Identifier = "ra-"+game.GameID,
+                LastUpdated = DateTime.UtcNow
             });
         }
         
@@ -111,7 +114,8 @@ public class RetroAchievementsService : IAchievementProvider<RetroAchievementsSe
             Platform = Platforms.RetroAchievements,
             PlaytimeMinutes = -1,
             Achievements = (await GetAchievements(gameId)).ToObservableCollection(),
-            Identifier = "ra-"+identifier
+            Identifier = "ra-"+identifier,
+            LastUpdated = DateTime.UtcNow
         };
     }
 

--- a/Alua/Services/Providers/SteamService.cs
+++ b/Alua/Services/Providers/SteamService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Sachya;
@@ -159,8 +160,9 @@ public sealed partial class SteamService : IAchievementProvider<SteamService>
                 Icon             = iconUrl,
                 Author           = string.Empty,
                 Platform         = Platforms.Steam,
-                PlaytimeMinutes  = data.playtime_forever,  
-                Achievements     = (await GetAchievementDataAsync(appId.ToString())).ToObservableCollection()
+                PlaytimeMinutes  = data.playtime_forever,
+                Achievements     = (await GetAchievementDataAsync(appId.ToString())).ToObservableCollection(),
+                LastUpdated      = DateTime.UtcNow
             };
         }
         catch (Exception ex)
@@ -247,7 +249,8 @@ public sealed partial class SteamService : IAchievementProvider<SteamService>
                 Platform        = Platforms.Steam,
                 PlaytimeMinutes = g.playtime_forever,
                 Identifier      = "steam-"+g.appid,
-                Achievements    = (await GetAchievementDataAsync(g.appid.ToString())).ToObservableCollection()
+                Achievements    = (await GetAchievementDataAsync(g.appid.ToString())).ToObservableCollection(),
+                LastUpdated     = DateTime.UtcNow
             });
 
             _appVm.LoadingGamesSummary = $"Scanned {g.name} ({src.IndexOf(g)}/{src.Count})";

--- a/Alua/Services/ViewModels/AppVM.cs
+++ b/Alua/Services/ViewModels/AppVM.cs
@@ -70,4 +70,4 @@ public partial class AppVM : ObservableRecipient
     }
 }
 
-public enum OrderBy { Name, CompletionPct, TotalCount, UnlockedCount, Playtime }
+public enum OrderBy { Name, CompletionPct, TotalCount, UnlockedCount, Playtime, LastUpdated }

--- a/Alua/UI/GameList.xaml
+++ b/Alua/UI/GameList.xaml
@@ -104,6 +104,10 @@
                                                          Content="Playtime"
                                                          GroupName="OrderBy"
                                                          Checked="Filter_Changed"/>
+                                            <RadioButton x:Name="RadioRecent"
+                                                         Content="Recently Played"
+                                                         GroupName="OrderBy"
+                                                         Checked="Filter_Changed"/>
                                             <CheckBox x:Name="CheckReverse"
                                                       Content="Reverse order"
                                                       Checked="Filter_Changed"

--- a/Alua/UI/GameList.xaml.cs
+++ b/Alua/UI/GameList.xaml.cs
@@ -219,6 +219,7 @@ public partial class GameList : Page
         else if (RadioTotal.IsChecked == true) _appVm.OrderBy = TotalCount;
         else if (RadioUnlocked.IsChecked == true) _appVm.OrderBy = UnlockedCount;
         else if (RadioPlaytime.IsChecked == true) _appVm.OrderBy = Playtime;
+        else if (RadioRecent.IsChecked == true) _appVm.OrderBy = LastUpdated;
 
         RefreshFiltered();
     }
@@ -237,6 +238,7 @@ public partial class GameList : Page
             TotalCount => list.OrderBy(g => g.Value.Achievements.Count),
             UnlockedCount => list.OrderBy(g => g.Value.UnlockedCount),
             Playtime => list.OrderBy(g => g.Value.PlaytimeMinutes),
+            LastUpdated => list.OrderByDescending(g => g.Value.LastUpdated),
             _ => list
         };
 


### PR DESCRIPTION
## Summary
- track the last time a `Game` object was updated
- set `LastUpdated` when fetching games from providers
- support ordering games by recently played

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ec695f42483309e7b230bfa166ae5