### PR TITLE
Persist game list filter settings

### DIFF
--- a/Alua/Services/ViewModels/SettingsVM.cs
+++ b/Alua/Services/ViewModels/SettingsVM.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Serilog;
 
+
 //When you can't even say my name
 namespace Alua.Services.ViewModels;
 /// <summary>
@@ -42,8 +43,30 @@ public partial class SettingsVM  : ObservableObject
     /// <summary>
     /// Controls if we show the first run dialog or game list
     /// </summary>
-    [ObservableProperty, JsonInclude, JsonPropertyName("Init")]    
+    [ObservableProperty, JsonInclude, JsonPropertyName("Init")]
     private bool _initialised;
+
+    // -----------------------------------------------------------
+    // Filter settings persisted between sessions
+    // -----------------------------------------------------------
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("HideComplete")]
+    private bool _hideComplete;
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("HideNoAchievements")]
+    private bool _hideNoAchievements;
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("HideUnstarted")]
+    private bool _hideUnstarted;
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("Reverse")]
+    private bool _reverse;
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("OrderBy")]
+    private OrderBy _orderBy = OrderBy.Name;
+
+    [ObservableProperty, JsonInclude, JsonPropertyName("SingleColumnLayout")]
+    private bool _singleColumnLayout;
 
     public SettingsVM()
     {


### PR DESCRIPTION
## Summary
- persist game list filter options inside `SettingsVM`
- sync filter UI and VM on navigation
- store filter selections whenever they change

## Testing
- `dotnet build --no-restore` *(fails: project uses unsupported SDK)*

------
https://chatgpt.com/codex/tasks/task_b_686ec6cc78448330b79698d5f5cbb8ad