### PR TITLE
Add search and favorites

### DIFF
--- a/Alua/Models/Game.cs
+++ b/Alua/Models/Game.cs
@@ -38,6 +38,12 @@ public class Game
     /// </summary>
     [JsonInclude, JsonPropertyName("PlaytimeMinutes")]
     public int PlaytimeMinutes { get; set; }
+
+    /// <summary>
+    /// Indicates if the game is marked as favourite
+    /// </summary>
+    [JsonInclude, JsonPropertyName("IsFavorite")]
+    public bool IsFavorite { get; set; }
     
     /// <summary>
     /// All achievements for this game
@@ -63,6 +69,7 @@ public class Game
         Achievements = new ObservableCollection<Achievement>();
         Identifier = string.Empty;
         LastUpdated = DateTime.UtcNow;
+        IsFavorite = false;
     }
 
     #region UI Helpers

--- a/Alua/Services/ViewModels/AppVM.cs
+++ b/Alua/Services/ViewModels/AppVM.cs
@@ -38,6 +38,10 @@ public partial class AppVM : ObservableRecipient
     [ObservableProperty]
     private bool _singleColumnLayout;
 
+    // Search query for filtering games
+    [ObservableProperty]
+    private string _searchQuery = string.Empty;
+
     public List<IAchievementProvider> Providers = new();
 
     public async Task ConfigureProviders()

--- a/Alua/UI/GameList.xaml
+++ b/Alua/UI/GameList.xaml
@@ -60,6 +60,10 @@
                                                        Style="{ThemeResource BaseTextBlockStyle}"
                                                        FontWeight="SemiBold"
                                                        Margin="0,0,0,4"/>
+                                            <TextBox x:Name="SearchBox"
+                                                     PlaceholderText="Search"
+                                                     Text="{x:Bind _appVm.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     TextChanged="SearchBox_TextChanged"/>
                                             <CheckBox x:Name="CheckHideComplete"
                                                       Content="Hide 100% Complete"
                                                       Checked="Filter_Changed"
@@ -163,6 +167,16 @@
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
                                         </Grid.ColumnDefinitions>
+                                        <ToggleButton x:Name="FavoriteToggle"
+                                                      IsChecked="{x:Bind IsFavorite, Mode=TwoWay}"
+                                                      Click="FavoriteToggle_Click"
+                                                      Grid.ColumnSpan="2"
+                                                      HorizontalAlignment="Right"
+                                                      VerticalAlignment="Top"
+                                                      Background="Transparent"
+                                                      BorderThickness="0">
+                                            <SymbolIcon Symbol="Favorite"/>
+                                        </ToggleButton>
                                         <!-- Left: Game Icon + Provider Icon -->
                                         <StackPanel Grid.Column="0" VerticalAlignment="Top"
                                                     HorizontalAlignment="Center" Margin="0,0,12,0" Spacing="6">

--- a/Alua/UI/GameList.xaml.cs
+++ b/Alua/UI/GameList.xaml.cs
@@ -3,6 +3,9 @@ using Alua.UI.Controls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Serilog;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using System;
 using AppVM = Alua.Services.ViewModels.AppVM;
 using SettingsVM = Alua.Services.ViewModels.SettingsVM;
 using static Alua.Services.ViewModels.OrderBy;
@@ -252,27 +255,31 @@ public partial class GameList : Page
 
     private void RefreshFiltered()
     {
-        var list = (_settingsVM.Games ?? new ())
+        var list = (_settingsVM.Games ?? new())
             .Where(g => !_appVm.HideComplete || g.Value.UnlockedCount < g.Value.Achievements.Count)
             .Where(g => !_appVm.HideNoAchievements || g.Value.HasAchievements)
-            .Where(g => !_appVm.HideUnstarted || g.Value.UnlockedCount > 0);
+            .Where(g => !_appVm.HideUnstarted || g.Value.UnlockedCount > 0)
+            .Where(g => string.IsNullOrWhiteSpace(_appVm.SearchQuery) ||
+                        g.Value.Name.Contains(_appVm.SearchQuery, StringComparison.OrdinalIgnoreCase));
 
-        list = _appVm.OrderBy switch
+        var ordered = list.OrderByDescending(g => g.Value.IsFavorite);
+
+        ordered = _appVm.OrderBy switch
         {
-            OrderBy.Name => list.OrderBy(g => g.Value.Name),
-            CompletionPct => list.OrderBy(g => (double)g.Value.UnlockedCount / g.Value.Achievements.Count),
-            TotalCount => list.OrderBy(g => g.Value.Achievements.Count),
-            UnlockedCount => list.OrderBy(g => g.Value.UnlockedCount),
-            Playtime => list.OrderBy(g => g.Value.PlaytimeMinutes),
-            LastUpdated => list.OrderByDescending(g => g.Value.LastUpdated),
-            _ => list
+            OrderBy.Name => ordered.ThenBy(g => g.Value.Name),
+            CompletionPct => ordered.ThenBy(g => (double)g.Value.UnlockedCount / g.Value.Achievements.Count),
+            TotalCount => ordered.ThenBy(g => g.Value.Achievements.Count),
+            UnlockedCount => ordered.ThenBy(g => g.Value.UnlockedCount),
+            Playtime => ordered.ThenBy(g => g.Value.PlaytimeMinutes),
+            LastUpdated => ordered.ThenByDescending(g => g.Value.LastUpdated),
+            _ => ordered
         };
 
-        if (_appVm.Reverse) { list = list.Reverse(); }
-        
+        var final = _appVm.Reverse ? ordered.Reverse() : ordered;
+
         // Clear and repopulate the existing collection instead of replacing it
         _appVm.FilteredGames.Clear();
-        foreach (var game in list.Select(g => g.Value))
+        foreach (var game in final.Select(g => g.Value))
         {
             _appVm.FilteredGames.Add(game);
         }
@@ -323,6 +330,25 @@ public partial class GameList : Page
         _settingsVM.SingleColumnLayout = toggle.IsOn;
         UpdateItemsLayout();
         await _settingsVM.Save();
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        _appVm.SearchQuery = SearchBox.Text;
+        RefreshFiltered();
+    }
+
+    private async void FavoriteToggle_Click(object sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        var toggle = (ToggleButton)sender;
+        if (toggle.DataContext is Game game)
+        {
+            game.IsFavorite = toggle.IsChecked == true;
+            _settingsVM.AddOrUpdateGame(game);
+            await _settingsVM.Save();
+            RefreshFiltered();
+        }
     }
 
     #region Async Commands


### PR DESCRIPTION
## Summary
- allow marking games as favorites and sort them to the top
- add search box to filter flyout
- keep favorites and search handling in game list

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68712c87620c8330bf249dbe1cca06ca