### PR TITLE
Fix macOS packaging font missing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -149,6 +149,11 @@ jobs:
           # Copy all application files to MacOS directory
           cp -R publish/* publish/Alua.app/Contents/MacOS/ 2>/dev/null || true
 
+          # Copy resources (fonts, etc.) into the bundle Resources directory
+          if [ -d publish/Resources ]; then
+            cp -R publish/Resources/* publish/Alua.app/Contents/Resources/
+          fi
+
           # Remove the app bundle from itself (avoid recursion)
           rm -rf publish/Alua.app/Contents/MacOS/Alua.app
 


### PR DESCRIPTION
## Summary
- update macOS packaging step to copy the Resources directory so font files are bundled

## Testing
- `dotnet restore Alua/Alua.sln` *(fails: .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_b_6880fdca13ac8330895a1812c54b8a3c