### PR TITLE
Fix macOS packaging font missing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -149,6 +149,17 @@ jobs:
           # Copy all application files to MacOS directory
           cp -R publish/* publish/Alua.app/Contents/MacOS/ 2>/dev/null || true
 
+          # Copy resources (fonts, etc.) into the bundle Resources directory
+          if [ -d publish/Resources ]; then
+            cp -R publish/Resources/* publish/Alua.app/Contents/Resources/
+          fi
+
+          # Ensure Uno.Fonts.Fluent fonts are copied to the expected location
+          if [ -d publish/Uno.Fonts.Fluent/Fonts ]; then
+            mkdir -p publish/Alua.app/Contents/MacOS/Uno.Fonts.Fluent/Fonts
+            cp publish/Uno.Fonts.Fluent/Fonts/* publish/Alua.app/Contents/MacOS/Uno.Fonts.Fluent/Fonts/
+          fi
+
           # Remove the app bundle from itself (avoid recursion)
           rm -rf publish/Alua.app/Contents/MacOS/Alua.app
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,9 +10,4 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Alternative: Create symbolic links to the Resources folder -->
-  <Target Name="CreateFontSymlinks" AfterTargets="CopyUnoFontsToMacOSBundle" Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(TargetFramework)' == 'net9.0-desktop'">
-    <Exec Command="mkdir -p '$(PublishDir)Alua.app/Contents/MacOS/Uno.Fonts.Fluent/Fonts'" />
-    <Exec Command="ln -sf '../../../Resources/Uno.Fonts.Fluent/Fonts/uno-fluentui-assets.ttf' '$(PublishDir)Alua.app/Contents/MacOS/Uno.Fonts.Fluent/Fonts/uno-fluentui-assets.ttf'" />
-  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- copy Uno.Fonts.Fluent font files into the macOS bundle
- remove symlink creation step

## Testing
- `dotnet restore Alua/Alua.sln` *(fails: missing workloads and missing SACHYA project)*

------
https://chatgpt.com/codex/tasks/task_b_6880fdca13ac8330895a1812c54b8a3c