### PR TITLE
Add network permission to Android manifest

### DIFF
--- a/Alua/Platforms/Android/AndroidManifest.xml
+++ b/Alua/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <!-- Allow network access -->
+  <uses-permission android:name="android.permission.INTERNET" />
+
   <application android:allowBackup="true" android:supportsRtl="true"></application>
 </manifest>


### PR DESCRIPTION
## Summary
- allow network access in Android manifest

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Alua.sln` *(fails: project file `/workspace/SACHYA/Sachya/Sachya.csproj` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68810d02efd08330b353870fd497a4d3